### PR TITLE
Add center of mass / centroid computation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[co]
+.venv
 
 # Packages
 *.egg

--- a/README.md
+++ b/README.md
@@ -31,6 +31,35 @@ Make sure you have [Python 3.6+](https://www.python.org/) installed. You can the
 
 After installation, you can run the `volume-calculator` command from any directory.
 
+## Using a virtual environment
+
+If you wish to modify this program it might come useful to use a virtual environment.
+This can be created and activated as follow :
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate # On Windows : .venv\Scripts\activate
+```
+
+Now install dependencies with :
+
+```bash
+pip install -r requirement.txt
+```
+
+If more dependencies are needed please regenerate this file with :
+
+```bash
+pip install my-package
+pip freeze > requirements.txt
+```
+
+When done with the virtual environment it can be deactivated with :
+
+```bash
+deactivate
+```
+
 ### Default Full Analysis
 
 This is the recommended and most common use case. Simply provide the path to your model.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,5 @@
 # requirements.txt
 
-# For numerical operations and STL file handling
-numpy>=1.19
-numpy-stl>=2.0
-
-# For medical imaging file support (NIfTI, DICOM)
-nibabel>=3.0
-pydicom>=2.0
-
-# For image processing and mesh generation (marching cubes)
-scikit-image>=0.19
-
 # For progress bars
 tqdm>=4.0
 

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,6 @@ setup(
     
     # List of dependencies needed for the project
     install_requires=[
-        'numpy>=1.19',
-        'numpy-stl>=2.0',
-        'nibabel>=3.0',
-        'pydicom>=2.0',
-        'scikit-image>=0.19',
         'tqdm>=4.0',
         'rich>=10.0'  # Added dependency for table formatting
     ],

--- a/volume_calculator.py
+++ b/volume_calculator.py
@@ -99,8 +99,8 @@ class STLUtils:
         v123 = p1[0] * p2[1] * p3[2]
         return (1.0 / 6.0) * (-v321 + v231 + v312 - v132 - v213 + v123)
 
-    def unpack(self, sig, l):
-        s = self.f.read(l)
+    def unpack(self, sig, count):
+        s = self.f.read(count)
         return struct.unpack(sig, s)
 
     def read_triangle_binary(self):
@@ -322,7 +322,7 @@ def main():
                 info_table.add_row("Bounding Box (cm)", bbox_str)
                 info_table.add_row("Surface Area", f"{props['surface_area_cm2']} cm²")
                 volume_display = f"{props['volume_inch3']} inch³" if args.unit == 'inch' else f"{props['volume_cm3']} cm³"
-                info_table.add_row(f"Volume (solid)", volume_display)
+                info_table.add_row("Volume (solid)", volume_display)
                 console.print(info_table)
 
                 mass_table = Table(title="Mass Estimates for All Materials With selected infill and 100% infill", show_header=True, header_style="bold magenta")

--- a/volume_calculator.py
+++ b/volume_calculator.py
@@ -230,12 +230,12 @@ class STLUtils:
         self,
     ) -> Tuple[float, Point3D]:
         """Computes the total volume of the loaded STL file, in cubed centimeters.
-        Also computes the centroid of the mesh.
+        Also computes the centroid of the mesh with coordinates in centimeters.
 
         Returns
         -------
         Tuple[float, Point3D]
-            Volume in cubed centimeters, coordinates of centroid of mesh
+            Volume in cubed centimeters, coordinates of centroid of mesh in centimeters
         """
         totalVolume = 0
         centroid = (0, 0, 0)
@@ -254,10 +254,11 @@ class STLUtils:
                 weighted_tetrahedron_centroid[1] + centroid[1],
                 weighted_tetrahedron_centroid[2] + centroid[2],
             )
+        # Return centroid in cm
         centroid = (
-            centroid[0] / totalVolume,
-            centroid[1] / totalVolume,
-            centroid[2] / totalVolume,
+            centroid[0] / totalVolume / 10,
+            centroid[1] / totalVolume / 10,
+            centroid[2] / totalVolume / 10,
         )
         # Return volume in cm³
         return totalVolume / 1000, centroid
@@ -351,7 +352,11 @@ def main():
                     "surface_area_cm2": f"{area_cm2:.4f}",
                     "volume_cm3": f"{volume_cm3:.4f}",
                     "volume_inch3": f"{mySTLUtils.cm3_to_inch3(volume_cm3):.4f}",
-                    "centroid_mm": f"({centroid[0]:.4f}, {centroid[1]:.4f}, {centroid[2]:.4f})",
+                    "centroid_cm": {
+                        "x": f"{centroid[0]:.2f}",
+                        "y": f"{centroid[1]:.2f}",
+                        "z": f"{centroid[2]:.2f}",
+                    },
                 },
                 "mass_estimates": [],
             }
@@ -389,7 +394,11 @@ def main():
                 results.update(
                     {
                         "volume_cm3": f"{volume_cm3:.4f}",
-                        "centroid_mm": f"({centroid[0]:.4f}, {centroid[1]:.4f}, {centroid[2]:.4f})",
+                        "centroid_cm": {
+                            "x": f"{centroid[0]:.2f}",
+                            "y": f"{centroid[1]:.2f}",
+                            "z": f"{centroid[2]:.2f}",
+                        },
                         "volume_inch3": f"{mySTLUtils.cm3_to_inch3(volume_cm3):.4f}",
                         "material_name": material_info["name"],
                         "mass_at_infill": {
@@ -420,7 +429,8 @@ def main():
                 info_table.add_row("Triangles", f"{props['triangle_count']:,}")
                 bbox_str = f"W: {props['bounding_box_cm']['width']}, D: {props['bounding_box_cm']['depth']}, H: {props['bounding_box_cm']['height']}"
                 info_table.add_row("Bounding Box (cm)", bbox_str)
-                info_table.add_row("Center of mass (mm)", f"{props['centroid_mm']}")
+                centroid_str = f"X: {props['centroid_cm']['x']}, Y: {props['centroid_cm']['y']}, Z: {props['centroid_cm']['z']}"
+                info_table.add_row("Center of mass (cm)", centroid_str)
                 info_table.add_row("Surface Area", f"{props['surface_area_cm2']} cm²")
                 volume_display = f"{props['volume_inch3']} inch³" if args.unit == 'inch' else f"{props['volume_cm3']} cm³"
                 info_table.add_row("Volume (solid)", volume_display)


### PR DESCRIPTION
First of all thank you for this project which is quite handy to work with some projects ! :grin: 
Here are my additions to it in order to fit my needs, please do not hesitate to ask me for changes if you disagree with some of my choices !

## What

Added computation of centroid coordinates, which is also the center of mass for materials with uniform density.

## Why

Because for personal projects I quite often need to know how my model will balance in the real-life.

## How

Modified method `calculate_volume` to become `calculate_volume_and_centroid`. This is done this way because both calculations need the individual signed volume of each triangle.

## What else

- Added good amount of docstrings and type hints to some methods, in order to explain how things are done.
- Removed unused dependencies from both `requirements.txt` and `setup.py`.
- Updated `README.md` to show how to setup and use a virtual environement during development.

## Example output

```txt
python3 volume_calculator.py ~/my_file.stl 
Reading triangles: 100%|████████████████████████| 1516/1516 [00:00<00:00, 298174.20it/s]
Calculating volume: 100%|████████████████████████| 1516/1516 [00:00<00:00, 365392.76it/s]
Calculating area  : 100%|████████████████████████| 1516/1516 [00:00<00:00, 400640.47it/s]
                  Model Analysis:                  
   my_file.stl    
╭─────────────────────┬───────────────────────────╮
│ File Size           │ 74.11 KB                  │
│ Triangles           │ 1,516                     │
│ Bounding Box (cm)   │ W: 3.00, D: 2.80, H: 9.98 │
│ Center of mass (cm) │ X: 1.44, Y: 1.40, Z: 3.24 │
│ Surface Area        │ 132.6962 cm²              │
│ Volume (solid)      │ 23.3373 cm³               │
╰─────────────────────┴───────────────────────────╯
```